### PR TITLE
Bump checkstyle from 10.3.1 to 10.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <checkstyle.base.rev>HEAD~</checkstyle.base.rev>
         <jgit.version>4.4.1.201607150455-r</jgit.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <checkstyle.version>10.3.1</checkstyle.version>
+        <checkstyle.version>10.14.2</checkstyle.version>
         <cli.version>1.4</cli.version>
         <lombok.version>1.18.2</lombok.version>
         <junit.version>4.13.1</junit.version>

--- a/src/main/java/io/github/yangziwen/checkstyle/Main.java
+++ b/src/main/java/io/github/yangziwen/checkstyle/Main.java
@@ -50,6 +50,7 @@ import org.apache.commons.logging.LogFactory;
 import org.eclipse.jgit.diff.HistogramDiff;
 import org.eclipse.jgit.util.StringUtils;
 
+import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean;
 import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
@@ -79,10 +80,6 @@ import io.github.yangziwen.checkstyle.diff.DiffCalculator;
 import io.github.yangziwen.checkstyle.diff.DiffEntryWrapper;
 import io.github.yangziwen.checkstyle.filter.DiffLineFilter;
 
-/**
- * Wrapper command line program for the Checker.
- * @noinspection UseOfSystemOutOrSystemErr
- **/
 /**
  * Wrapper command line program for the Checker.
  * @noinspection UseOfSystemOutOrSystemErr
@@ -448,13 +445,12 @@ public final class Main {
         if (cmdLine.hasOption(cliParameterName)) {
             final String checkerThreadsNumberStr =
                 cmdLine.getOptionValue(cliParameterName);
-            if (CommonUtil.isInt(checkerThreadsNumberStr)) {
+            try {
                 final int checkerThreadsNumber = Integer.parseInt(checkerThreadsNumberStr);
                 if (checkerThreadsNumber < 1) {
                     result.add(mustBeGreaterThanZeroMessage);
                 }
-            }
-            else {
+            } catch (NumberFormatException ignored) {
                 result.add(invalidNumberMessage);
             }
         }
@@ -626,7 +622,7 @@ public final class Main {
                 }
 
                 listener = new XpathFileGeneratorAuditListener(System.out,
-                        AutomaticBean.OutputStreamOptions.NONE);
+                        AbstractAutomaticBean.OutputStreamOptions.NONE);
             }
             else {
                 listener = createListener(cliOptions.format,


### PR DESCRIPTION
Checkstyle version bumped from 10.3.1 to 10.14.2 with broken backwards compatibility fixes.

This versión includes, notably, a fix for [checkstyle#12020](https://github.com/checkstyle/checkstyle/issues/12020).